### PR TITLE
ci: update setup-zig to v2 and use latest stable Zig version in workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: latest
       - run: zig build docs
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: latest
       - run: zig build test
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: latest
       - run: zig fmt --check .


### PR DESCRIPTION
- Switch from setup-zig@v1 to setup-zig@v2 for improved reliability and support.
- Use 'version: latest' to avoid failures due to missing or purged nightly/dev Zig builds.
- Ensures Zig is always available in CI/CD and reduces maintenance overhead.

I am dependabot jk